### PR TITLE
Update github build action to use git from svn 

### DIFF
--- a/.github/workflows/build_extend.yml
+++ b/.github/workflows/build_extend.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: 'moos-ivp-extend'
-      - run: svn co https://oceanai.mit.edu/svn/moos-ivp-aro/trunk/ moos-ivp
+      - run: git clone https://github.com/moos-ivp/moos-ivp.git
       - name: Build MOOS-IvP
         working-directory: moos-ivp
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # moos-ivp-extend
 
+[![Build MOOS-IvP Extend repository](https://github.com/davidbertucci/moos-ivp-extend/actions/workflows/build_extend.yml/badge.svg)](https://github.com/davidbertucci/moos-ivp-extend/actions/workflows/build_extend.yml)
+
 |              |                        |
 |:------------ |:---------------------- |
 | FILE:        | moos-ivp-extend/README |


### PR DESCRIPTION
GitHub build action in `.github/workflows/build_extend.yml` was failing due to not having `svn` installed to get the main moos-ivp repo. 

Updated this command in `build_extend.yml` to get the current version of moos-ivp with `git clone https://github.com/moos-ivp/moos-ivp.git`. Tested to make sure action succeeds.

Also added build badge to `README.md` to show users status of build.